### PR TITLE
hotfix/broken workspace

### DIFF
--- a/erpnext_thailand/thai_tax/workspace/thai_tax/thai_tax.json
+++ b/erpnext_thailand/thai_tax/workspace/thai_tax/thai_tax.json
@@ -24,9 +24,9 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Tax Invoice Setting",
+   "label": "Thai Tax Setting",
    "link_count": 0,
-   "link_to": "Tax Invoice Settings",
+   "link_to": "Thai Tax Settings",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"


### PR DESCRIPTION
Thai Tax Workspace is broken due to missing doctype.  As new doctype is implemented, but json file does not update accordingly.