### PR TITLE
Insert comment when print pdf

### DIFF
--- a/erpnext_thailand/custom/custom_api.py
+++ b/erpnext_thailand/custom/custom_api.py
@@ -516,3 +516,25 @@ def cancel_related_tax_invoice(doc, method):
 		if tinv:
 			tinv = frappe.get_doc(doctype, tinv[0])
 			tinv.cancel()
+
+
+@frappe.whitelist()
+def add_comment(
+	reference_doctype,
+	reference_name,
+	comment_type="Comment",
+	text=None,
+	comment_email=None,
+	comment_by=None,
+):
+	return frappe.get_doc(
+		{
+			"doctype": "Comment",
+			"comment_type": comment_type,
+			"comment_email": comment_email or frappe.session.user,
+			"comment_by": comment_by,
+			"reference_doctype": reference_doctype,
+			"reference_name": reference_name,
+			"content": text or comment_type,
+		}
+	).insert(ignore_permissions=True)

--- a/erpnext_thailand/public/js/print_format.js
+++ b/erpnext_thailand/public/js/print_format.js
@@ -1,6 +1,7 @@
 frappe.provide("erpnext_thailand.print");
 
-erpnext_thailand.print.print_pdf = function(doc) {
+erpnext_thailand.print.print_pdf = function(frm, log=false) {
+	let doc = frm.doc
 	// Fetch default print formats for the given doctype and docname
 	frappe.call({
 		method: "erpnext_thailand.custom.print_format.get_print_formats",
@@ -48,6 +49,23 @@ erpnext_thailand.print.print_pdf = function(doc) {
 							frappe.msgprint(__("Please enable pop-ups"));
 						}
 						d.hide();
+						// Write Log
+						if (log) {
+							frappe.call({
+								method: "erpnext_thailand.custom.custom_api.add_comment",
+								args: {
+									reference_doctype: doc.doctype,
+									reference_name: doc.name,
+									comment_type: "Edit",
+									text: "Printed: " + print_format,
+								},
+								callback: function(r) {
+									if (!r.exc) {
+										frm.reload_doc();
+									}
+								}
+							})
+						}
 					}
 				});
 				d.show();


### PR DESCRIPTION
When printing a PDF, the printer's activity log will display the name of the person who printed it and the name of the PDF.
![image](https://github.com/user-attachments/assets/cf4fdd2e-9fb0-4636-8d39-f51777f5ce56)

For display log, just add parameter **log=true** in function print_pdf
![image](https://github.com/user-attachments/assets/918aeb5d-7d55-43b1-a443-3b5dce235c4e)

Could you please review ?
@kittiu @Saralrat 