### PR TITLE
Create pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "erpnext_thailand"
+authors = [
+    { name = "Ecosoft", email = "kittiu@ecosoft.co.th"}
+]
+description = "ERPNEXT THAILAND"
+requires-python = ">=3.10"
+readme = "README.md"
+dynamic = ["version"]
+dependencies = [
+    # "frappe~=15.0.0" # Installed and managed by bench.
+]
+
+[build-system]
+requires = ["flit_core >=3.4,<4"]
+build-backend = "flit_core.buildapi"
+
+# These dependencies are only installed when developer mode is enabled
+[tool.bench.dev-dependencies]
+# package_name = "~=1.1.0"


### PR DESCRIPTION
Fixed for this error:

pod@ecosoft:~/Workspace/frappe/buc$ bench get-app https://github.com/newtratip/erpnext_thailand.git --branch main
A directory for the application 'erpnext_thailand' already exists. Do you want to continue and overwrite it? [y/N]: y
INFO: App moved from apps/erpnext_thailand to archived/apps/erpnext_thailand-2025-05-26
Getting erpnext_thailand
$ git clone https://github.com/newtratip/erpnext_thailand.git --branch main --depth 1 --origin upstream
Cloning into 'erpnext_thailand'...
remote: Enumerating objects: 258, done.
remote: Counting objects: 100% (258/258), done.
remote: Compressing objects: 100% (200/200), done.
remote: Total 258 (delta 74), reused 147 (delta 42), pack-reused 0 (from 0)
Receiving objects: 100% (258/258), 926.03 KiB | 4.70 MiB/s, done.
Resolving deltas: 100% (74/74), done.
Ignoring dependencies of https://github.com/newtratip/erpnext_thailand.git. To install dependencies use --resolve-deps
Installing erpnext_thailand
$ /home/pod/Workspace/frappe/buc/env/bin/python -m pip install --quiet --upgrade -e /home/pod/Workspace/frappe/buc/apps/erpnext_thailand 
  DEPRECATION: Legacy editable install of erpnext_thailand==1.0.1 from file:///home/pod/Workspace/frappe/buc/apps/erpnext_thailand (setup.py develop) is deprecated. pip 25.3 will enforce this behaviour change. A possible replacement is to add a pyproject.toml or enable --use-pep517, and use setuptools >= 64. If the resulting installation is not behaving as expected, try using --config-settings editable_mode=compat. Please consult the setuptools documentation for more information. Discussion can be found at https://github.com/pypa/pip/issues/11457
    error: subprocess-exited-with-error
    
    × python setup.py develop did not run successfully.
    │ exit code: 1
    ╰─> [87 lines of output]
        running develop
        /home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/setuptools/_distutils/cmd.py:90: DevelopDeprecationWarning: develop command is deprecated.
        !!
        
                ********************************************************************************
                Please avoid running ``setup.py`` and ``develop``.
                Instead, use standards-based tools like pip or uv.
        
                By 2025-Oct-31, you need to update your project and remove deprecated calls
                or your builds will no longer be supported.
        
                See https://github.com/pypa/setuptools/issues/917 for details.
                ********************************************************************************
        
        !!
          self.initialize_options()
        Obtaining file:///home/pod/Workspace/frappe/buc/apps/erpnext_thailand
          Installing build dependencies: started
          Installing build dependencies: finished with status 'done'
          Checking if build backend supports build_editable: started
          Checking if build backend supports build_editable: finished with status 'done'
          Getting requirements to build editable: started
          Getting requirements to build editable: finished with status 'error'
          error: subprocess-exited-with-error
        
          × Getting requirements to build editable did not run successfully.
          │ exit code: 1
          ╰─> [25 lines of output]
              Traceback (most recent call last):
                File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
                  main()
                File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
                  json_out["return_val"] = hook(**hook_input["kwargs"])
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 157, in get_requires_for_build_editable
                  return hook(config_settings)
                         ^^^^^^^^^^^^^^^^^^^^^
                File "/tmp/pip-build-env-a5dzbea1/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 473, in get_requires_for_build_editable
                  return self.get_requires_for_build_wheel(config_settings)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                File "/tmp/pip-build-env-a5dzbea1/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
                  return self._get_build_requires(config_settings, requirements=[])
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                File "/tmp/pip-build-env-a5dzbea1/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
                  self.run_setup()
                File "/tmp/pip-build-env-a5dzbea1/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 512, in run_setup
                  super().run_setup(setup_script=setup_script)
                File "/tmp/pip-build-env-a5dzbea1/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 317, in run_setup
                  exec(code, locals())
                File "<string>", line 7, in <module>
                File "/home/pod/Workspace/frappe/buc/apps/erpnext_thailand/erpnext_thailand/__init__.py", line 5, in <module>
                  import erpnext.accounts.doctype.gl_entry.gl_entry as gl_entry
              ModuleNotFoundError: No module named 'erpnext'
              [end of output]
        
          note: This error originates from a subprocess, and is likely not a problem with pip.
        error: subprocess-exited-with-error
        
        × Getting requirements to build editable did not run successfully.
        │ exit code: 1
        ╰─> See above for output.
        
        note: This error originates from a subprocess, and is likely not a problem with pip.
        Traceback (most recent call last):
          File "<string>", line 2, in <module>
          File "<pip-setuptools-caller>", line 35, in <module>
          File "/home/pod/Workspace/frappe/buc/apps/erpnext_thailand/setup.py", line 9, in <module>
            setup(
          File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/setuptools/__init__.py", line 115, in setup
            return distutils.core.setup(**attrs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 186, in setup
            return run_commands(dist)
                   ^^^^^^^^^^^^^^^^^^
          File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 202, in run_commands
            dist.run_commands()
          File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1002, in run_commands
            self.run_command(cmd)
          File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/setuptools/dist.py", line 1102, in run_command
            super().run_command(command)
          File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1021, in run_command
            cmd_obj.run()
          File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/setuptools/command/develop.py", line 39, in run
            subprocess.check_call(cmd)
          File "/usr/lib/python3.12/subprocess.py", line 413, in check_call
            raise CalledProcessError(retcode, cmd)
        subprocess.CalledProcessError: Command '['/home/pod/Workspace/frappe/buc/env/bin/python', '-m', 'pip', 'install', '-e', '.', '--use-pep517', '--no-deps']' returned non-zero exit status 1.
        [end of output]
    
    note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× python setup.py develop did not run successfully.
│ exit code: 1
╰─> [87 lines of output]
    running develop
    /home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/setuptools/_distutils/cmd.py:90: DevelopDeprecationWarning: develop command is deprecated.
    !!
    
            ********************************************************************************
            Please avoid running ``setup.py`` and ``develop``.
            Instead, use standards-based tools like pip or uv.
    
            By 2025-Oct-31, you need to update your project and remove deprecated calls
            or your builds will no longer be supported.
    
            See https://github.com/pypa/setuptools/issues/917 for details.
            ********************************************************************************
    
    !!
      self.initialize_options()
    Obtaining file:///home/pod/Workspace/frappe/buc/apps/erpnext_thailand
      Installing build dependencies: started
      Installing build dependencies: finished with status 'done'
      Checking if build backend supports build_editable: started
      Checking if build backend supports build_editable: finished with status 'done'
      Getting requirements to build editable: started
      Getting requirements to build editable: finished with status 'error'
      error: subprocess-exited-with-error
    
      × Getting requirements to build editable did not run successfully.
      │ exit code: 1
      ╰─> [25 lines of output]
          Traceback (most recent call last):
            File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
              main()
            File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
              json_out["return_val"] = hook(**hook_input["kwargs"])
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 157, in get_requires_for_build_editable
              return hook(config_settings)
                     ^^^^^^^^^^^^^^^^^^^^^
            File "/tmp/pip-build-env-a5dzbea1/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 473, in get_requires_for_build_editable
              return self.get_requires_for_build_wheel(config_settings)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/tmp/pip-build-env-a5dzbea1/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
              return self._get_build_requires(config_settings, requirements=[])
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/tmp/pip-build-env-a5dzbea1/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
              self.run_setup()
            File "/tmp/pip-build-env-a5dzbea1/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 512, in run_setup
              super().run_setup(setup_script=setup_script)
            File "/tmp/pip-build-env-a5dzbea1/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 317, in run_setup
              exec(code, locals())
            File "<string>", line 7, in <module>
            File "/home/pod/Workspace/frappe/buc/apps/erpnext_thailand/erpnext_thailand/__init__.py", line 5, in <module>
              import erpnext.accounts.doctype.gl_entry.gl_entry as gl_entry
          ModuleNotFoundError: No module named 'erpnext'
          [end of output]
    
      note: This error originates from a subprocess, and is likely not a problem with pip.
    error: subprocess-exited-with-error
    
    × Getting requirements to build editable did not run successfully.
    │ exit code: 1
    ╰─> See above for output.
    
    note: This error originates from a subprocess, and is likely not a problem with pip.
    Traceback (most recent call last):
      File "<string>", line 2, in <module>
      File "<pip-setuptools-caller>", line 35, in <module>
      File "/home/pod/Workspace/frappe/buc/apps/erpnext_thailand/setup.py", line 9, in <module>
        setup(
      File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/setuptools/__init__.py", line 115, in setup
        return distutils.core.setup(**attrs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 186, in setup
        return run_commands(dist)
               ^^^^^^^^^^^^^^^^^^
      File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 202, in run_commands
        dist.run_commands()
      File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1002, in run_commands
        self.run_command(cmd)
      File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/setuptools/dist.py", line 1102, in run_command
        super().run_command(command)
      File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1021, in run_command
        cmd_obj.run()
      File "/home/pod/Workspace/frappe/buc/env/lib/python3.12/site-packages/setuptools/command/develop.py", line 39, in run
        subprocess.check_call(cmd)
      File "/usr/lib/python3.12/subprocess.py", line 413, in check_call
        raise CalledProcessError(retcode, cmd)
    subprocess.CalledProcessError: Command '['/home/pod/Workspace/frappe/buc/env/bin/python', '-m', 'pip', 'install', '-e', '.', '--use-pep517', '--no-deps']' returned non-zero exit status 1.
    [end of output]

note: This error originates from a subprocess, and is likely not a problem with pip.
ERROR: /home/pod/Workspace/frappe/buc/env/bin/python -m pip install --quiet --upgrade -e /home/pod/Workspace/frappe/buc/apps/erpnext_thailand 
subprocess.CalledProcessError: Command '/home/pod/Workspace/frappe/buc/env/bin/python -m pip install --quiet --upgrade -e /home/pod/Workspace/frappe/buc/apps/erpnext_thailand ' returned non-zero exit status 1.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/bin/bench", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/usr/local/lib/python3.12/dist-packages/bench/cli.py", line 132, in cli
    bench_command()
  File "/usr/local/lib/python3.12/dist-packages/bench/commands/make.py", line 181, in get_app
    get_app(
  File "/usr/local/lib/python3.12/dist-packages/bench/app.py", line 778, in get_app
    app.install(verbose=verbose, skip_assets=skip_assets, restart_bench=restart_bench)
  File "/usr/local/lib/python3.12/dist-packages/bench/utils/render.py", line 126, in wrapper_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/bench/app.py", line 253, in install
    install_app(
  File "/usr/local/lib/python3.12/dist-packages/bench/app.py", line 924, in install_app
    bench.run(
  File "/usr/local/lib/python3.12/dist-packages/bench/bench.py", line 49, in run
    return exec_cmd(cmd, cwd=cwd or self.cwd, _raise=_raise, env=env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/bench/utils/__init__.py", line 181, in exec_cmd
    raise CommandFailedError(cmd) from subprocess.CalledProcessError(return_code, cmd)
bench.exceptions.CommandFailedError: /home/pod/Workspace/frappe/buc/env/bin/python -m pip install --quiet --upgrade -e /home/pod/Workspace/frappe/buc/apps/erpnext_thailand

@kittiu please merge