### PR TITLE
Allow create wht cert on draft payment

### DIFF
--- a/erpnext_thailand/custom/dashboard_overrides.py
+++ b/erpnext_thailand/custom/dashboard_overrides.py
@@ -32,7 +32,11 @@ def get_dashboard_data_for_expense_claim(data):
 
 
 def get_dashboard_data_for_payment_entry(data):
-	data["transactions"].append(
-		{"items": ["Payment Receipt"]}
+	data["non_standard_fieldnames"].update({"Withholding Tax Cert": "voucher_no"})
+	data["transactions"].extend(
+		[
+			{"items": ["Payment Receipt"]},
+			{"items": ["Withholding Tax Cert"]}
+		]
 	)
 	return data

--- a/erpnext_thailand/public/js/payment_entry.js
+++ b/erpnext_thailand/public/js/payment_entry.js
@@ -14,13 +14,23 @@ frappe.ui.form.on("Payment Entry", {
 			frm.trigger("add_withholding_tax_deduction_buttons");
 		}
 		// Add button to create withholding tax cert
-		if (
-			frm.doc.docstatus == 1 &&
-			frm.doc.payment_type == "Pay" &&
-			frm.doc.deductions.length > 0
-		) {
-			frm.trigger("add_create_withholding_tax_cert_button");
-		}
+		frappe.db.get_single_value("Withholding Tax Setting", "allow_wht_cert_in_draft_payment").then((allow_draft) => {
+			frappe.db.get_list(
+				"Withholding Tax Cert", {
+					filters: [
+						["voucher_type", "=", "Payment Entry"],
+						["voucher_no", "=", frm.doc.name],
+						["docstatus", "!=", 2]]}).then((wht_cert) => {
+				if (
+					(frm.doc.docstatus == 1 || (frm.doc.docstatus == 0 && allow_draft == 1)) &&
+					wht_cert.length == 0 &&
+					frm.doc.payment_type == "Pay" &&
+					frm.doc.deductions.length > 0
+				) {
+					frm.trigger("add_create_withholding_tax_cert_button");
+				}
+			});
+		})
 		// Create Clear Undue VAT Journal Entry
 		if (frm.doc.docstatus == 1) {
 			frm.trigger("add_create_undue_vat_journal_entry_button");

--- a/erpnext_thailand/thai_tax/doctype/withholding_tax_cert/withholding_tax_cert.js
+++ b/erpnext_thailand/thai_tax/doctype/withholding_tax_cert/withholding_tax_cert.js
@@ -27,6 +27,13 @@ frappe.ui.form.on("Withholding Tax Cert", {
 				},
 			};
 		});
+		frm.set_query("voucher_no", function () {
+			return {
+				filters: {
+					docstatus: ["!=", 2],
+				}
+			};
+		})
 	},
 });
 

--- a/erpnext_thailand/thai_tax/doctype/withholding_tax_cert/withholding_tax_cert.py
+++ b/erpnext_thailand/thai_tax/doctype/withholding_tax_cert/withholding_tax_cert.py
@@ -1,9 +1,76 @@
 # Copyright (c) 2023, Kitti U. and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
 class WithholdingTaxCert(Document):
-	pass
+	def has_voucher(self):
+		return self.voucher_type and self.voucher_no
+
+	def validate_duplicate_wht_cert(self):
+		wht_cert_count = frappe.db.count(
+			"Withholding Tax Cert",
+			{
+				"voucher_type": self.voucher_type,
+				"voucher_no": self.voucher_no,
+				"docstatus": ["!=", 2]
+			}
+		)
+		if wht_cert_count > 1:
+			frappe.throw(_("Withholding Tax Cert has already been created for {} {}").format(
+				self.voucher_type, self.voucher_no))
+
+	def validate_voucher_is_submitted(self):
+		voucher = frappe.get_doc(self.voucher_type, self.voucher_no)
+		if voucher.docstatus != 1:
+			frappe.throw(_("Please submit {} before submit this withholding tax cert.").format(
+				voucher.name))
+
+	def validate_wht_cert_matches_payment(self):
+		if self.voucher_type == "Payment Entry":
+			voucher = frappe.get_doc(self.voucher_type, self.voucher_no)
+			payment_wht = {}
+			for deduction in voucher.get("deductions"):
+				base = deduction.get("withholding_tax_base", 0)
+				amount = deduction.get("amount", 0)
+				rate = 0
+				wht_type = deduction.get("withholding_tax_type")
+				if wht_type:
+					rate = frappe.get_cached_value("Withholding Tax Type", wht_type, "percent")
+				if rate not in payment_wht:
+					payment_wht[rate] = {
+						"tax_base": -base,
+						"tax_amount": -amount,
+					}
+				else:
+					payment_wht[rate].update({
+						"tax_base": payment_wht[rate]["tax_base"] - base,
+						"tax_amount": payment_wht[rate]["tax_amount"] - amount,
+					})
+			wht_cert = {}
+			for item in self.withholding_tax_items:
+				rate = item.tax_rate if item.tax_rate else 0
+				if rate not in wht_cert:
+					wht_cert[rate] = {
+						"tax_base": item.tax_base,
+						"tax_amount": item.tax_amount,
+					}
+				else:
+					wht_cert[rate].update({
+						"tax_base": wht_cert[rate]["tax_base"] + item.tax_base,
+						"tax_amount": wht_cert[rate]["tax_amount"] + item.tax_amount,
+					})
+			if dict(sorted(payment_wht.items())) != dict(sorted(wht_cert.items())):
+				frappe.throw(_("Withholding tax details in the certificate do not align with the payment deductions."))
+
+	def on_update(self):
+		if self.has_voucher():
+			self.validate_duplicate_wht_cert()
+
+	def before_submit(self):
+		if self.has_voucher():
+			self.validate_voucher_is_submitted()
+			self.validate_wht_cert_matches_payment()

--- a/erpnext_thailand/thai_tax/doctype/withholding_tax_setting/withholding_tax_setting.json
+++ b/erpnext_thailand/thai_tax/doctype/withholding_tax_setting/withholding_tax_setting.json
@@ -7,20 +7,33 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "wht_cert_image"
+  "wht_cert_image",
+  "column_break_zxsv",
+  "allow_wht_cert_in_draft_payment"
  ],
  "fields": [
   {
    "fieldname": "wht_cert_image",
    "fieldtype": "Attach Image",
    "label": "WHT Cert Image"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_wht_cert_in_draft_payment",
+   "fieldtype": "Check",
+   "label": "Allow WHT Cert in Draft Payment"
+  },
+  {
+   "fieldname": "column_break_zxsv",
+   "fieldtype": "Column Break"
   }
  ],
+ "grid_page_length": 50,
  "image_field": "wht_cert_image",
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-03-04 12:14:13.207499",
+ "modified": "2025-06-18 23:32:21.379374",
  "modified_by": "Administrator",
  "module": "Thai Tax",
  "name": "Withholding Tax Setting",
@@ -37,6 +50,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
Ref issue: https://github.com/ecosoft-frappe/erpnext_thailand/issues/32

### Setting

- Add `Allow WHT Cert in Draft Payment` field in `Withholding Tax Setting` menu
![Screenshot from 2025-06-19 17-33-13](https://github.com/user-attachments/assets/9ac9836d-6951-4429-aa3f-65cac6f50d64)
- If checked this field, you can create WHT cert on draft payment entry

### Payment Entry

- Hide create WHT Cert button if WHT Cert created already
- Add Withholding Tax Cert Link on Connections Section
![Screenshot from 2025-06-19 17-40-11](https://github.com/user-attachments/assets/6a97380c-d2b5-41ba-85b7-7ee556ea7489)

### WHT Cert

- Filter voucher not with status not cancelled
![Screenshot from 2025-06-19 17-42-18](https://github.com/user-attachments/assets/ee350051-5c98-4fe3-a4b8-cba675010c6b)
- Not allow duplicate WHT Cert
![Screenshot from 2025-06-19 17-44-04](https://github.com/user-attachments/assets/7089bca4-0f21-4566-82d5-101db212b693)
- WHT Cert can not submit if payment entry still not submitted
![Screenshot from 2025-06-19 17-45-48](https://github.com/user-attachments/assets/b8328d4c-ace7-45f2-b346-c295bda1472f)
- WHT base / amount must align with payment deduction
![Screenshot from 2025-06-19 17-48-03](https://github.com/user-attachments/assets/b359da96-20d6-452a-9aee-d439ae4914d0)
