### PR TITLE
Fix wording to handle if base_amount = 0

### DIFF
--- a/erpnext_thailand/custom/payment_entry.py
+++ b/erpnext_thailand/custom/payment_entry.py
@@ -81,7 +81,7 @@ def get_withholding_tax_from_type(filters, doc):
 			if root_type in ["Asset", "Income", "Expense"] and account_type in valid_types:
 				base_amount += alloc_percent * (credit - debit)
 	if not base_amount:
-		frappe.throw(_("There is nothing to withhold tax for"))
+		frappe.throw(_("The accounts eligible for withholding tax deduction were not found."))
 	sign = -1 if pay.party_type == "Receive" else 1
 	return {
 		"withholding_tax_type": wht.name,

--- a/erpnext_thailand/translations/th.csv
+++ b/erpnext_thailand/translations/th.csv
@@ -9194,3 +9194,5 @@
 "← Back to upload files","← กลับไปที่อัปโหลดไฟล์",""
 "Select All","เลือกทั้งหมด",""
 "Status","สถานะ",""
+"The accounts eligible for withholding tax deduction were not found.","ไม่พบบัญชีที่มีสิทธิ์หักภาษี ณ ที่จ่าย",
+


### PR DESCRIPTION
Fix wording 
This is the origin wording if there is no base amount to calculate WHT
![Selection_506](https://github.com/user-attachments/assets/58600b84-52fe-4c46-b065-b69ac3f75f7b)

So after discuss with team I thought we should change it to _The accounts eligible for withholding tax deduction were not found._