### PR TITLE
[FIX] Returning Invoice must not use both negative rate and qty when create Tax Invoice

### DIFF
--- a/erpnext_thailand/custom/gl_entry.py
+++ b/erpnext_thailand/custom/gl_entry.py
@@ -1,19 +1,18 @@
 import frappe
 from frappe.model.naming import set_name_from_naming_options
+from frappe.utils import now
 
 
 def rename_temporarily_named_docs(doctype):
 	"""Rename temporarily named docs using autoname options"""
-	docs_to_rename = frappe.get_all(
-		doctype, {"to_rename": "1"}, order_by="creation", limit=50000
-	)
+	docs_to_rename = frappe.get_all(doctype, {"to_rename": "1"}, order_by="creation", limit=50000)
 	for doc in docs_to_rename:
 		oldname = doc.name
 		set_name_from_naming_options(frappe.get_meta(doctype).autoname, doc)
 		newname = doc.name
 		frappe.db.sql(
-			f"UPDATE `tab{doctype}` SET name = %s, to_rename = 0 where name = %s",
-			(newname, oldname),
+			f"UPDATE `tab{doctype}` SET name = %s, to_rename = 0, modified = %s where name = %s",
+			(newname, now(), oldname),
 			auto_commit=True,
 		)
 		# Monkey patch


### PR DESCRIPTION
Currently, Returning Purchase Invoice (Credit Note) with negative in both rate and quantity will create Sales Tax Invoice (it should be Purchase Tax Invoice)

Ensure that this will not happen. The checking is done in Sales Tax Invoice and Purchase Tax Invoice, ensureing the correct account assigned.

<img width="1028" height="302" alt="image" src="https://github.com/user-attachments/assets/ad95ecee-af10-40ab-93b2-800f102d398f" />
