### PR TITLE
Fix Tax Invoice to use correct company

### DIFF
--- a/erpnext_thailand/custom/custom_api.py
+++ b/erpnext_thailand/custom/custom_api.py
@@ -189,7 +189,6 @@ def create_tax_invoice(doc, doctype, base_amount, tax_amount, voucher, split_tax
 				tinv_dict.update(
 					{
 						"party": tax.supplier,
-						"company": voucher.company,
 						"tax_amount": tax.tax_amount,
 						"tax_base": tax.tax_base_amount,
 						"number": tax.tax_invoice_number,

--- a/erpnext_thailand/custom/custom_api.py
+++ b/erpnext_thailand/custom/custom_api.py
@@ -171,6 +171,7 @@ def create_tax_invoice(doc, doctype, base_amount, tax_amount, voucher, split_tax
 	tinv_dict.update(
 		{
 			"doctype": doctype,
+			"company": voucher.company,
 			"gl_entry": doc.name,
 			"tax_amount": tax_amount,
 			"tax_base": base_amount,
@@ -188,6 +189,7 @@ def create_tax_invoice(doc, doctype, base_amount, tax_amount, voucher, split_tax
 				tinv_dict.update(
 					{
 						"party": tax.supplier,
+						"company": voucher.company,
 						"tax_amount": tax.tax_amount,
 						"tax_base": tax.tax_base_amount,
 						"number": tax.tax_invoice_number,

--- a/erpnext_thailand/custom/custom_api.py
+++ b/erpnext_thailand/custom/custom_api.py
@@ -171,7 +171,7 @@ def create_tax_invoice(doc, doctype, base_amount, tax_amount, voucher, split_tax
 	tinv_dict.update(
 		{
 			"doctype": doctype,
-			"company": voucher.company,
+			"company": doc.company,
 			"gl_entry": doc.name,
 			"tax_amount": tax_amount,
 			"tax_base": base_amount,


### PR DESCRIPTION
จากการทดสอบ multi-company พบว่า Sales Tax Invoice กับ GL Entry มีค่า company ไม่ตรงกัน ซึ่งก่อนหน้านี้เราได้ปิดการ validate account เพื่อให้สร้างเอกสารได้ก่อน แต่เมื่อฟังก์ชัน validate_account ทำงาน ก็จะตรวจสอบ account ตาม company ของ Sales Tax Invoice ทำให้เกิดการแจ้งเตือนว่า Account นั้นไม่ตรงกับ company

<img width="1434" height="849" alt="image" src="https://github.com/user-attachments/assets/c5c075ea-cc34-4a65-8457-f16d8bfe20df" />

<img width="1408" height="900" alt="image" src="https://github.com/user-attachments/assets/edf9a5b5-6d9b-46f7-8778-3b341ce6ba5d" />


เพื่อแก้ปัญหานี้ จึงได้เพิ่มการกำหนดค่า company ให้กับเอกสาร Tax Invoice ทุกกรณี ไม่ว่าจะเป็น:

1. กรณีไม่ split tax invoice

- กำหนด tinv_dict["company"] = voucher.company

2. กรณี split tax invoice

- เพิ่ม company ให้ในแต่ละบรรทัดของ split tax invoices

เมื่อแก้ไขแล้ว company ในเอกสาร Tax Invoice จะถูกต้องค่ะ

<img width="1408" height="900" alt="image" src="https://github.com/user-attachments/assets/43d1a6e8-d67c-4b7e-937d-ee9e8a50dd62" />

<img width="1408" height="900" alt="image" src="https://github.com/user-attachments/assets/3f0ddcc0-d755-4bb6-be5c-b5cfb21fbeb0" />
