### PR TITLE
set line-height to 1.2 in tax report

### DIFF
--- a/erpnext_thailand/thai_tax/report/purchase_tax_report/purchase_tax_report.html
+++ b/erpnext_thailand/thai_tax/report/purchase_tax_report/purchase_tax_report.html
@@ -41,6 +41,7 @@
 		vertical-align: top !important;
 		padding: 2px !important;
 		color: #000000 !important;
+		line-height: 1.2;
 	}
 	.print-format th {
 		vertical-align: top !important;

--- a/erpnext_thailand/thai_tax/report/sales_tax_report/sales_tax_report.html
+++ b/erpnext_thailand/thai_tax/report/sales_tax_report/sales_tax_report.html
@@ -41,6 +41,7 @@
 		vertical-align: top !important;
 		padding: 2px !important;
 		color: #000000 !important;
+		line-height: 1.2;
 	}
 	.print-format th {
 		vertical-align: top !important;


### PR DESCRIPTION
When generating the Sales Tax Report and Purchase Tax Report, if a text entry exceeds two lines, the content on a single page may overflow the defined space. This causes the data to shift onto the next page, resulting in a blank page being generated.

To resolve this issue, margin adjustments were applied in the code. Testing confirmed that even when each row spans two full lines, the content still fits within a single page without producing additional blank pages.

<img width="1185" height="830" alt="image" src="https://github.com/user-attachments/assets/84eec9cc-0fac-4779-9ca5-8bff2ab8d3e7" />

from issue: #29 Thai Tax Report printout problem