### PR TITLE
feat: BOT API Authorization; rename client_id to token in Currency Exchange Settings.

### DIFF
--- a/erpnext_thailand/constants.py
+++ b/erpnext_thailand/constants.py
@@ -436,10 +436,10 @@ ERP_CUSTOM_FIELDS = {
     "Currency Exchange Settings": [
 		{
 			"depends_on": "eval:doc.service_provider == 'Bank of Thailand';",
-			"fieldname": "client_id",
+			"fieldname": "token",
 			"fieldtype": "Password",
 			"insert_after": "access_key",
-			"label": "Client ID",
+			"label": "Token",
 			"mandatory_depends_on": "eval:doc.service_provider == 'Bank of Thailand';",
 			"module": "Thai Tax"
 		},

--- a/erpnext_thailand/custom/currency_exchange_bot_api.py
+++ b/erpnext_thailand/custom/currency_exchange_bot_api.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 
 @frappe.whitelist(allow_guest=True)
 def get_api_currency_exchange(
-	from_currency, to_currency, transaction_date, client_id=None):
+	from_currency, to_currency, transaction_date, token=None):
 	# Convert the transaction_date string to a datetime object
 	trans_start_date = datetime.strptime(transaction_date, "%Y-%m-%d")
 	trans_start_date = trans_start_date - timedelta(days=5)
@@ -20,18 +20,19 @@ def get_api_currency_exchange(
 	end_date = trans_end_date
 	currency = from_currency
 
-	if not client_id:
+	if not token:
 		currency_exchange_settings = frappe.get_single("Currency Exchange Settings")
-		client_id = currency_exchange_settings.get_password("client_id")
+		token = currency_exchange_settings.get_password("token")
 
-	conn = http.client.HTTPSConnection("apigw1.bot.or.th")
+	conn = http.client.HTTPSConnection("gateway.api.bot.or.th")
 	headers = {
-		"X-IBM-Client-Id": client_id,
-		"accept": "application/json"
+		"Authorization": token,
+		"accept": "application/json",
+        "Content-Type": "application/json",
 	}
 
 	# Properly formatted URL with dynamic date parameters
-	url_path = f"/bot/public/Stat-ExchangeRate/v2/DAILY_AVG_EXG_RATE/?start_period={start_date}&end_period={end_date}&currency={currency}"
+	url_path = f"/Stat-ExchangeRate/v2/DAILY_AVG_EXG_RATE/?start_period={start_date}&end_period={end_date}&currency={currency}"
 	conn.request("GET", url_path, headers=headers)
 
 	# Respose

--- a/erpnext_thailand/custom/currency_exchange_settings.py
+++ b/erpnext_thailand/custom/currency_exchange_settings.py
@@ -14,7 +14,7 @@ class CurrencyExchangeSettings(CurrencyExchangeSettings):
 				params[row.key] = row.value.format(
 					transaction_date=nowdate(), to_currency="THB", from_currency="USD"
 				)
-			params["client_id"] = self.client_id
+			params["token"] = self.token
 			api_url = self.api_endpoint.format(
 				transaction_date=nowdate(), to_currency="THB", from_currency="USD")
 			try:

--- a/erpnext_thailand/patches.txt
+++ b/erpnext_thailand/patches.txt
@@ -16,3 +16,4 @@ erpnext_thailand.patches.add_deposit_custom_fields
 erpnext_thailand.patches.rerun_deposit_custom_fields
 erpnext_thailand.patches.rerun_purchase_invoice_custom_fields
 erpnext_thailand.patches.rerun_expense_claim_custom_fields
+erpnext_thailand.patches.rename_exchange_client_id_to_token

--- a/erpnext_thailand/patches/rename_exchange_client_id_to_token.py
+++ b/erpnext_thailand/patches/rename_exchange_client_id_to_token.py
@@ -1,0 +1,11 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from erpnext_thailand.constants import ERP_CUSTOM_FIELDS
+
+
+def execute():
+    frappe.db.delete("Custom Field", {"fieldname": "client_id", "dt": "Currency Exchange Settings"})
+    custom_fields = {
+        "Currency Exchange Settings": list(filter(lambda l: l["fieldname"] in ["token"], ERP_CUSTOM_FIELDS["Currency Exchange Settings"]))
+    }
+    create_custom_fields(custom_fields, ignore_validate=True)

--- a/erpnext_thailand/public/js/currency_exchange_settings.js
+++ b/erpnext_thailand/public/js/currency_exchange_settings.js
@@ -57,7 +57,7 @@ frappe.ui.form.on("Currency Exchange Settings", {
 			frm.events.set_table_parameters(frm);
 			frm.events.set_table_result_key(frm);
         } else {
-			frm.set_value("client_id", null);
+			frm.set_value("token", null);
             frm.toggle_display("use_http", true);
         }
     }


### PR DESCRIPTION
- Switch BOT API header from x-ibm-client-id to Authorization.
- Rename client_id to token in Currency Exchange Settings.

<img width="1585" height="714" alt="image" src="https://github.com/user-attachments/assets/1a406356-3bde-4a42-9209-e6605e9f2b30" />

from issue: #57 BOT new API need to be implemented.