### PR TITLE
[FIX]: round tax_amount to 2 decimal places in Withholding Tax

### DIFF
--- a/erpnext_thailand/thai_tax/doctype/withholding_tax_cert/withholding_tax_cert.js
+++ b/erpnext_thailand/thai_tax/doctype/withholding_tax_cert/withholding_tax_cert.js
@@ -35,6 +35,6 @@ frappe.ui.form.on("Withholding Tax Items", {
 	// Helper to calculate tax amount from given rate
 	tax_rate: function (frm, cdt, cdn) {
 		var row = locals[cdt][cdn];
-		frappe.model.set_value(cdt, cdn, "tax_amount", (row.tax_base * row.tax_rate) / 100);
+		frappe.model.set_value(cdt, cdn, "tax_amount", flt((row.tax_base * row.tax_rate) / 100, precision("tax_amount", row)));
 	},
 });

--- a/erpnext_thailand/thai_tax/doctype/withholding_tax_cert/withholding_tax_cert.py
+++ b/erpnext_thailand/thai_tax/doctype/withholding_tax_cert/withholding_tax_cert.py
@@ -3,10 +3,7 @@
 
 # import frappe
 from frappe.model.document import Document
-from frappe.utils import flt
 
 
 class WithholdingTaxCert(Document):
-	def validate(self):
-		for item in self.withholding_tax_items:
-			item.tax_amount = flt((item.tax_base or 0) * (item.tax_rate or 0) / 100, 2)
+	pass


### PR DESCRIPTION
**Pain Point:**

เนื่องจากในระบบ frappe ที่หน้า UI นั้นมีการปัดทศนิยมเป็น 2 ตำแหน่ง แต่ใน DB นั้นบันทึกเป็นจำนวนจริงๆ ที่ไม่ได้ปัดเศษขึ้น จึงเกิดปัญหาที่หน้า ui แสดงข้อมูล และที่ฟอร์มแสดงข้อมูลไม่เหมือนกัน

- ที่หน้าจอแสดงผล

<img width="1052" height="135" alt="Screenshot 2568-11-19 at 13 57 25" src="https://github.com/user-attachments/assets/f8b3dab9-adca-4153-a075-7138632a2680" />

- ใน DB

<img width="447" height="642" alt="Screenshot 2568-11-19 at 14 02 25" src="https://github.com/user-attachments/assets/25e456a6-34be-436a-9ce9-96f7ca2eee47" />

- ที่ฟอร์มแสดงผล (นำข้อมูลมาจาก DB ปัดเศษลง)

<img width="457" height="78" alt="Screenshot 2568-11-19 at 14 05 05" src="https://github.com/user-attachments/assets/cb982fee-1c4a-48a0-8f6b-0f499c9846a2" />

**Resolving:**

จึงทำการเพิ่มการคำนวณที่ฝั่ง Server ของ DocType `Withholding Tax Cert` เพื่อให้ `tax_amount` ถูกคำนวณและปัดเป็น 2 ตำแหน่งก่อนบันทึกลง DB ทำให้ค่าที่แสดงใน UI และที่บันทึกใน DB สอดคล้องกัน