### PR TITLE
perf: do not fetch dynamic links separately

### DIFF
--- a/erpnext_thailand/custom/address.py
+++ b/erpnext_thailand/custom/address.py
@@ -2,14 +2,16 @@ import frappe
 
 def update_tax_info_in_linked_doc(doc, method):
     if doc.update_tax_branch:
-        linked_docs = frappe.get_all("Dynamic Link", filters={
-            "parenttype": "Address",
-            "parent": doc.name
-        }, fields=["link_doctype", "link_name"])
+        linked_docs = doc.links
+        did_update = False
 
         for link in linked_docs:
             if link.link_doctype in ["Customer", "Supplier"]:
-                frappe.db.set_value(link.link_doctype, link.link_name, "tax_id", doc.tax_id)
-                frappe.db.set_value(link.link_doctype, link.link_name, "branch_code", doc.branch_code)
-
-        frappe.msgprint("Tax ID and Branch Code updated in linked Customer/Supplier.", alert=True, indicator="green")
+                frappe.db.set_value(link.link_doctype, link.link_name, {
+                    "tax_id": doc.tax_id,
+                    "branch_code": doc.branch_code
+                })
+                did_update = True
+        
+        if did_update:
+            frappe.msgprint("Tax ID and Branch Code updated in linked Customer/Supplier.", alert=True, indicator="green")


### PR DESCRIPTION
We already have the entire Address in `doc` - including the Dynamic Links, so we don't need to fetch it again using `get_all`. The `set_value` is also combined to reduce number of queries.

Also, for UX, the message should only be shown if the address was linked to a Customer/Supplier and an update happened.