### PR TITLE
Split module into v15, v16

### DIFF
--- a/erpnext_thailand/custom/print_format.py
+++ b/erpnext_thailand/custom/print_format.py
@@ -3,6 +3,7 @@ from io import BytesIO
 from pypdf import PdfWriter
 
 import frappe
+from frappe.tests.utils import toggle_test_mode
 from frappe.utils.safe_exec import get_safe_globals
 
 
@@ -50,7 +51,7 @@ def allow_update_standard(doc, method):
       			prev_doc.default_condition != doc.default_condition or
       			prev_doc.hide_if_not_default != doc.hide_if_not_default
          	):
-			frappe.flags.in_test = 1
+			toggle_test_mode(True)
 
 
 @frappe.whitelist()

--- a/erpnext_thailand/thai_billing/doctype/payment_receipt/payment_receipt.json
+++ b/erpnext_thailand/thai_billing/doctype/payment_receipt/payment_receipt.json
@@ -167,7 +167,7 @@
    "write": 1
   }
  ],
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/erpnext_thailand/thai_billing/doctype/payment_receipt_billing_reference/payment_receipt_billing_reference.json
+++ b/erpnext_thailand/thai_billing/doctype/payment_receipt_billing_reference/payment_receipt_billing_reference.json
@@ -78,7 +78,7 @@
  "name": "Payment Receipt Billing Reference",
  "owner": "Administrator",
  "permissions": [],
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/erpnext_thailand/thai_billing/doctype/payment_receipt_payment_reference/payment_receipt_payment_reference.json
+++ b/erpnext_thailand/thai_billing/doctype/payment_receipt_payment_reference/payment_receipt_payment_reference.json
@@ -113,7 +113,7 @@
  "name": "Payment Receipt Payment Reference",
  "owner": "Administrator",
  "permissions": [],
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/erpnext_thailand/thai_billing/doctype/purchase_billing/purchase_billing.json
+++ b/erpnext_thailand/thai_billing/doctype/purchase_billing/purchase_billing.json
@@ -215,7 +215,7 @@
    "write": 1
   }
  ],
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/erpnext_thailand/thai_billing/doctype/purchase_billing_line/purchase_billing_line.json
+++ b/erpnext_thailand/thai_billing/doctype/purchase_billing_line/purchase_billing_line.json
@@ -79,7 +79,7 @@
  "name": "Purchase Billing Line",
  "owner": "Administrator",
  "permissions": [],
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/erpnext_thailand/thai_billing/doctype/sales_billing/sales_billing.json
+++ b/erpnext_thailand/thai_billing/doctype/sales_billing/sales_billing.json
@@ -229,7 +229,7 @@
    "write": 1
   }
  ],
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/erpnext_thailand/thai_billing/doctype/sales_billing_line/sales_billing_line.json
+++ b/erpnext_thailand/thai_billing/doctype/sales_billing_line/sales_billing_line.json
@@ -80,7 +80,7 @@
  "name": "Sales Billing Line",
  "owner": "Administrator",
  "permissions": [],
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/erpnext_thailand/thai_billing/doctype/thai_billing_settings/thai_billing_settings.json
+++ b/erpnext_thailand/thai_billing/doctype/thai_billing_settings/thai_billing_settings.json
@@ -36,7 +36,7 @@
    "write": 1
   }
  ],
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/erpnext_thailand/thai_deposit/doctype/item_deposit_account/item_deposit_account.json
+++ b/erpnext_thailand/thai_deposit/doctype/item_deposit_account/item_deposit_account.json
@@ -50,7 +50,7 @@
  "owner": "Administrator",
  "permissions": [],
  "row_format": "Dynamic",
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/erpnext_thailand/thai_deposit/doctype/purchase_invoice_deposit/purchase_invoice_deposit.json
+++ b/erpnext_thailand/thai_deposit/doctype/purchase_invoice_deposit/purchase_invoice_deposit.json
@@ -64,7 +64,7 @@
  "owner": "Administrator",
  "permissions": [],
  "row_format": "Dynamic",
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/erpnext_thailand/thai_deposit/doctype/sales_invoice_deposit/sales_invoice_deposit.json
+++ b/erpnext_thailand/thai_deposit/doctype/sales_invoice_deposit/sales_invoice_deposit.json
@@ -64,7 +64,7 @@
  "owner": "Administrator",
  "permissions": [],
  "row_format": "Dynamic",
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/erpnext_thailand/thai_tax/doctype/journal_entry_tax_invoice_detail/journal_entry_tax_invoice_detail.json
+++ b/erpnext_thailand/thai_tax/doctype/journal_entry_tax_invoice_detail/journal_entry_tax_invoice_detail.json
@@ -107,7 +107,7 @@
  "name": "Journal Entry Tax Invoice Detail",
  "owner": "Administrator",
  "permissions": [],
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/erpnext_thailand/thai_tax/doctype/purchase_tax_invoice/purchase_tax_invoice.json
+++ b/erpnext_thailand/thai_tax/doctype/purchase_tax_invoice/purchase_tax_invoice.json
@@ -272,7 +272,7 @@
  ],
  "row_format": "Dynamic",
  "show_title_field_in_link": 1,
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],
  "title_field": "number",

--- a/erpnext_thailand/thai_tax/doctype/sales_tax_invoice/sales_tax_invoice.json
+++ b/erpnext_thailand/thai_tax/doctype/sales_tax_invoice/sales_tax_invoice.json
@@ -256,7 +256,7 @@
    "write": 1
   }
  ],
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],
  "track_changes": 1

--- a/erpnext_thailand/thai_tax/doctype/thai_tax_settings/thai_tax_settings.json
+++ b/erpnext_thailand/thai_tax/doctype/thai_tax_settings/thai_tax_settings.json
@@ -41,7 +41,7 @@
    "write": 1
   }
  ],
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/erpnext_thailand/thai_tax/doctype/thai_tax_settings_company/thai_tax_settings_company.json
+++ b/erpnext_thailand/thai_tax/doctype/thai_tax_settings_company/thai_tax_settings_company.json
@@ -103,7 +103,7 @@
  "name": "Thai Tax Settings Company",
  "owner": "Administrator",
  "permissions": [],
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/erpnext_thailand/thai_tax/doctype/thai_zip_code/thai_zip_code.json
+++ b/erpnext_thailand/thai_tax/doctype/thai_zip_code/thai_zip_code.json
@@ -64,7 +64,7 @@
    "write": 1
   }
  ],
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/erpnext_thailand/thai_tax/doctype/withholding_tax_cert/withholding_tax_cert.json
+++ b/erpnext_thailand/thai_tax/doctype/withholding_tax_cert/withholding_tax_cert.json
@@ -203,7 +203,7 @@
    "write": 1
   }
  ],
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],
  "title_field": "supplier_name",

--- a/erpnext_thailand/thai_tax/doctype/withholding_tax_items/withholding_tax_items.json
+++ b/erpnext_thailand/thai_tax/doctype/withholding_tax_items/withholding_tax_items.json
@@ -84,7 +84,7 @@
  "name": "Withholding Tax Items",
  "owner": "Administrator",
  "permissions": [],
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/erpnext_thailand/thai_tax/doctype/withholding_tax_setting/withholding_tax_setting.json
+++ b/erpnext_thailand/thai_tax/doctype/withholding_tax_setting/withholding_tax_setting.json
@@ -37,7 +37,7 @@
    "write": 1
   }
  ],
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/erpnext_thailand/thai_tax/doctype/withholding_tax_type_account/withholding_tax_type_account.json
+++ b/erpnext_thailand/thai_tax/doctype/withholding_tax_type_account/withholding_tax_type_account.json
@@ -38,7 +38,7 @@
  "name": "Withholding Tax Type Account",
  "owner": "Administrator",
  "permissions": [],
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }


### PR DESCRIPTION
### Summary

Split the module baseline to support ERPNext v15 and v16. This ports the v15 baseline and applies v16 migration adjustments modules according to the manual.

### Changes

- Split module structure for v15 / v16
- Default sorting changed from modified to creation
- Replace deprecated `frappe.flags.in_test` with `frappe.in_test`
