### PR TITLE
[Feat] Manual key-in Tax Invoice Number/Date for zero-tax Sales Invoice (#93)

### DIFF
--- a/erpnext_thailand/custom/custom_api.py
+++ b/erpnext_thailand/custom/custom_api.py
@@ -224,9 +224,18 @@ def update_voucher_tinv(doctype, voucher, tinv, split_tax_invoice=False):
 	# Sales Invoice - use Sales Tax Invoice as Tax Invoice
 	# Purchase Invoice - use Bill No as Tax Invoice
 	if doctype == "Sales Tax Invoice":
-		voucher.tax_invoice_number = tinv.name
-		voucher.tax_invoice_date = tinv.date
-		tinv.report_date = tinv.date
+		setting = get_thai_tax_settings(voucher.company)
+		if setting.create_sales_taxinv_on_zero_tax and setting.get("manual_keyin_sales_taxinv_on_zero_tax") and tinv.tax_amount == 0:
+			# Manual mode: behave like Purchase Tax Invoice — use user-provided number and date
+			if not (voucher.tax_invoice_number and voucher.tax_invoice_date):
+				frappe.throw(_("Please enter Tax Invoice Number / Tax Invoice Date"))
+			tinv.number = voucher.tax_invoice_number
+			tinv.report_date = tinv.date = voucher.tax_invoice_date
+		else:
+			# Auto mode (default): derive number and date from generated Tax Invoice
+			voucher.tax_invoice_number = tinv.name
+			voucher.tax_invoice_date = tinv.date
+			tinv.report_date = tinv.date
 	if doctype == "Purchase Tax Invoice":
 		if not (voucher.tax_invoice_number and voucher.tax_invoice_date):
 			frappe.throw(_("Please enter Tax Invoice Number / Tax Invoice Date"))
@@ -269,6 +278,21 @@ def validate_tax_invoice(doc, method):
 			frappe.throw(_("This document require Tax Invoice Number(s)"))
 		if not has_vat and doc.splitted_tax_invoices:
 			frappe.throw(_("This document has no due VAT, please remove Tax Invoice Number(s)"))
+
+
+def validate_sales_tax_invoice_zero_tax(doc, method):
+	"""When manual key-in is enabled, require Tax Invoice Number/Date on zero-tax Sales Invoices."""
+	setting = get_thai_tax_settings(doc.company)
+	if not (setting.create_sales_taxinv_on_zero_tax and setting.get("manual_keyin_sales_taxinv_on_zero_tax")):
+		return
+	zero_taxes = [t for t in doc.taxes if (
+		t.account_head == setting.sales_tax_account and t.tax_amount == 0
+	)]
+	if zero_taxes:
+		if not doc.tax_invoice_number:
+			frappe.throw(_("This document requires Tax Invoice Number"))
+		if not doc.tax_invoice_date:
+			frappe.throw(_("This document requires Tax Invoice Date"))
 
 
 @frappe.whitelist()

--- a/erpnext_thailand/hooks.py
+++ b/erpnext_thailand/hooks.py
@@ -179,6 +179,7 @@ doc_events = {
         "on_submit": "erpnext_thailand.custom.unreconcile_payment.unreconcile_undue_tax",
 	},
     "Sales Invoice": {
+        "validate": "erpnext_thailand.custom.custom_api.validate_sales_tax_invoice_zero_tax",
         "on_submit": "erpnext_thailand.custom.custom_api.create_sales_tax_invoice_on_zero_tax",
 		"before_cancel": "erpnext_thailand.custom.custom_api.cancel_related_tax_invoice",
         "before_validate": [

--- a/erpnext_thailand/thai_tax/doctype/thai_tax_settings_company/thai_tax_settings_company.json
+++ b/erpnext_thailand/thai_tax/doctype/thai_tax_settings_company/thai_tax_settings_company.json
@@ -13,6 +13,7 @@
   "column_break_dymu",
   "use_doc_name_for_sales_taxinv",
   "create_sales_taxinv_on_zero_tax",
+  "manual_keyin_sales_taxinv_on_zero_tax",
   "section_break_vsbj",
   "purchase_tax_account",
   "purchase_tax_account_undue",
@@ -92,6 +93,13 @@
    "fieldname": "create_sales_taxinv_on_zero_tax",
    "fieldtype": "Check",
    "label": "Create Sales Tax Invoice for Zero Tax"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.create_sales_taxinv_on_zero_tax",
+   "fieldname": "manual_keyin_sales_taxinv_on_zero_tax",
+   "fieldtype": "Check",
+   "label": "Manual key-in Tax Invoice Number/Date"
   }
  ],
  "index_web_pages_for_search": 1,


### PR DESCRIPTION
https://github.com/ecosoft-frappe/erpnext_thailand/issues/93

- Add `manual_keyin_sales_taxinv_on_zero_tax` field to Thai Tax Settings Company (visible only when 'Create Sales Tax Invoice for Zero Tax' is enabled)
- Add `validate_sales_tax_invoice_zero_tax()` to enforce Tax Invoice Number/Date on zero-tax Sales Invoices when manual key-in mode is active
- Update `update_voucher_tinv()` to use user-provided number/date for Sales Tax Invoice in manual mode (mirrors Purchase Tax Invoice behavior)
- Register new validate hook for Sales Invoice in hooks.py