### PR TITLE
fix: error create multi-payment with auto allocate amount to each payment

### DIFF
--- a/erpnext_thailand/thai_billing/doctype/sales_billing/sales_billing.py
+++ b/erpnext_thailand/thai_billing/doctype/sales_billing/sales_billing.py
@@ -99,7 +99,7 @@ def create_multi_payment_entries(payment_details, sales_billing_name, posting_da
             "reference_date": detail.chequereference_date,
         })
         for line in sales_billing.sales_billing_line:
-            if not line.sales_invoice or not line.outstanding_amount:
+            if not line.sales_invoice or not frappe.db.get_value("Sales Invoice", line.sales_invoice, "outstanding_amount"):
                 continue
             allocated = 1 if line.outstanding_amount > 0 else -1
             payment_entry.append("references", {


### PR DESCRIPTION
**Step to test**

1. Create sales billing and get multiple invoices
2. Submit sales billing
3. Click Create Multi-Payments button and fill in payment details
4. Check Auto allocate amount to each payment
5. The system throw error "Sales Invoice xx has already been fully paid."
<img width="1411" height="837" alt="Screenshot from 2026-05-11 20-54-32" src="https://github.com/user-attachments/assets/1e48496b-487d-49e8-ab3b-23b59a2acea0" />

This pr fixed it, could you approve / merge ?
@kittiu 