### PR TITLE
feat: auto-populate payment_references from sales_billing in Payment Receipt

### DIFF
--- a/erpnext_thailand/thai_billing/doctype/payment_receipt/payment_receipt.js
+++ b/erpnext_thailand/thai_billing/doctype/payment_receipt/payment_receipt.js
@@ -1,8 +1,17 @@
 // Copyright (c) 2024, FLO and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Payment Receipt", {
-// 	refresh(frm) {
+frappe.ui.form.on("Payment Receipt", {
+	refresh(frm) {
+		frm.set_query("sales_billing", () => ({
+			filters: {
+				customer: frm.doc.customer,
+				docstatus: 1,
+			},
+		}));
+	},
 
-// 	},
-// });
+	customer(frm) {
+		frm.set_value("sales_billing", "");
+	},
+});

--- a/erpnext_thailand/thai_billing/doctype/payment_receipt/payment_receipt.py
+++ b/erpnext_thailand/thai_billing/doctype/payment_receipt/payment_receipt.py
@@ -9,8 +9,9 @@ from collections import defaultdict
 class PaymentReceipt(Document):
 
     def validate(self):
-        self.update_total_paid_amount()
+        self.update_payment_references()
         self.update_billing_references()
+        self.update_total_paid_amount()
 
     def on_submit(self):
         self.check_payment_references()
@@ -24,6 +25,12 @@ class PaymentReceipt(Document):
             if payment.docstatus != 1:unsubmitted_references.append(payment.name)
         if unsubmitted_references:
             frappe.throw(_("Unsubmitted Payment References: {0}").format(", ".join(unsubmitted_references)))
+
+    def update_payment_references(self):
+        pe_names = get_payment_entries_for_billing(self.sales_billing) if self.sales_billing else []
+        self.payment_references = []
+        for name in pe_names:
+            self.append("payment_references", {"payment_entry": name})
 
     def update_billing_references(self):
         self.billing_references = []
@@ -52,3 +59,18 @@ class PaymentReceipt(Document):
     def update_total_paid_amount(self):
         self.total_paid_amount = sum([r.paid_amount for r in self.payment_references])
         self.total_invoice_amount = sum([r.grand_total for r in self.billing_references])
+
+    def get_payment_entries_for_billing(sales_billing):
+        result = frappe.get_all("Payment Entry", {"sales_billing": sales_billing, "docstatus": 1}, pluck="name")
+        if result:
+            return result
+
+        invoices = frappe.get_all("Sales Billing Line", {"parent": sales_billing}, pluck="sales_invoice")
+        if not invoices:
+            return []
+
+        pe_names = list(set(frappe.get_all("Payment Entry Reference", {
+            "reference_doctype": "Sales Invoice", "reference_name": ["in", invoices],
+        }, pluck="parent")))
+
+        return frappe.get_all("Payment Entry", {"name": ["in", pe_names], "docstatus": 1}, pluck="name") if pe_names else []

--- a/erpnext_thailand/thai_tax/workspace/thai_tax/thai_tax.json
+++ b/erpnext_thailand/thai_tax/workspace/thai_tax/thai_tax.json
@@ -154,9 +154,9 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Purchase Receipt",
+   "label": "Payment Receipt",
    "link_count": 0,
-   "link_to": "Purchase Receipt",
+   "link_to": "Payment Receipt",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"


### PR DESCRIPTION
## Summary
- Auto-populate `payment_references` child table when `sales_billing` is selected in Payment Receipt
- Filter `sales_billing` dropdown by customer
- Fix `total_invoice_amount` showing 0 (validate order)

## Changes
- `payment_receipt.py`: add `update_payment_references()` in `validate`, similar to `update_billing_references()`
- `payment_receipt.py`: add `get_payment_entries_for_billing()` — finds PEs by `sales_billing` field, fallback via invoice references
- `payment_receipt.js`: add `set_query` to filter `sales_billing` by customer; clear on customer change