### PR TITLE
fix: clear stale exchange rate cache when BOT rate type changes

### DIFF
--- a/erpnext_thailand/custom/currency_exchange_bot_api.py
+++ b/erpnext_thailand/custom/currency_exchange_bot_api.py
@@ -11,6 +11,23 @@ RATE_TYPE_FIELD_MAP = {
 }
 
 
+def clear_exchange_rate_cache(doc, method=None):
+	if not doc.has_value_changed("bot_currency_rate_type"):
+		return
+
+	currency = doc.name
+	suffix = f":{currency}".encode()
+	middle = f":{currency}:".encode()
+	cache = frappe.cache()
+	stale_keys = [
+		key
+		for key in cache.keys("currency_exchange_rate_*")
+		if key.endswith(suffix) or middle in key
+	]
+	if stale_keys:
+		cache.delete(*stale_keys)
+		
+
 @frappe.whitelist(allow_guest=True)
 def get_api_currency_exchange(
 	from_currency, to_currency, transaction_date, token=None):

--- a/erpnext_thailand/hooks.py
+++ b/erpnext_thailand/hooks.py
@@ -216,7 +216,10 @@ doc_events = {
     },
     "Item": {
         "validate": "erpnext_thailand.custom.item.validate_deposit_item",
-	}
+	},
+    "Currency": {
+        "on_update": "erpnext_thailand.custom.currency_exchange_bot_api.clear_exchange_rate_cache",
+    }
 }
 
 # Scheduled Tasks


### PR DESCRIPTION
### Problem

The system retrieves exchange rates from the Bank of Thailand (BOT) based on the rate type selected in the bot_currency_rate_type field of the Currency doctype (Mid Rate / Selling Rate / Buying Sight Rate / Buying Transfer Rate).

However, if a user changes this rate type later (after the exchange rate for that date has already been viewed/fetched once), the system does not fetch the new rate according to the newly selected type. It continues to return the previously cached rate until the cache expires several hours later.

### Root Cause

ERPNext’s core function get_exchange_rate() (used by Sales Invoice and other transactions) caches fetched exchange rates in Redis for 6 hours.

The cache key is based only on:

- exchange date
- from currency
- to currency

It does not include the selected BOT rate type. Therefore, changing bot_currency_rate_type does not invalidate the existing cache entry, and the system keeps returning the old rate from Redis instead of calling the BOT API again.

### Fix

An on_update hook was added to the Currency doctype.

Whenever the bot_currency_rate_type field is changed and the document is saved, the hook checks whether the field value has actually changed. If it has, the system immediately deletes all related exchange-rate cache entries for that currency from Redis.