### PR TITLE
fix: support multiple tax rates when validating tax invoice amount

### DIFF
--- a/erpnext_thailand/custom/custom_api.py
+++ b/erpnext_thailand/custom/custom_api.py
@@ -80,12 +80,21 @@ def create_tax_invoice_on_gl_tax(doc, method):
 				base_amount = voucher.tax_base_amount
 			base_amount = abs(base_amount) * sign
 			# Validate base amount
-			tax_rate = frappe.get_cached_value("Account", doc.account, "tax_rate")
-			if abs((base_amount * tax_rate / 100) - tax_amount) > 0.2:
+			item_wise_tax_amount = None
+			if doc.voucher_type in ("Sales Invoice", "Purchase Invoice"):
+				item_wise_tax_amount = get_item_wise_tax_amount(voucher, doc.account)
+			if item_wise_tax_amount is not None:
+				expected_tax = item_wise_tax_amount
+			else:
+				tax_rate = frappe.get_cached_value("Account", doc.account, "tax_rate")
+				expected_tax = abs(base_amount * tax_rate / 100)
+			if abs(expected_tax - abs(tax_amount)) > 0.2:
 				frappe.throw(
 					_(
-         				"Tax should be {}% of the base amount<br/>"
-					  	"<b>Note:</b> To correct base amount, fill in Tax Base Amount.".format(tax_rate)
+						"Tax amount should be {0}, but got {1}<br/>"
+						"<b>Note:</b> To correct base amount, fill in Tax Base Amount.".format(
+							expected_tax, abs(tax_amount)
+						)
 					)
 				)
 			if voucher.get("split_tax_invoice", False):
@@ -99,6 +108,17 @@ def create_tax_invoice_on_gl_tax(doc, method):
 				[tinv] = create_tax_invoice(doc, doctype, base_amount, tax_amount, voucher)
 				tinv = update_voucher_tinv(doctype, voucher, tinv)
 				tinv.submit()
+
+
+def get_item_wise_tax_amount(voucher, account):
+	item_tax_rows = voucher.get("item_wise_tax_details") or []
+	if not item_tax_rows:
+		return None
+	tax_row_names = {tax.name for tax in voucher.get("taxes", []) if tax.account_head == account}
+	if not tax_row_names:
+		return None
+	amounts = [flt(d.amount) for d in item_tax_rows if d.tax_row in tax_row_names]
+	return abs(sum(amounts)) if amounts else None
 
 
 def validate_splitted_tax_invoices(voucher, tax_account):


### PR DESCRIPTION
Summary

- create_tax_invoice_on_gl_tax is used to validate VAT with a single flat formula that mixes multiple tax rates on one document (e.g. 7% and 0%)

- Validation sums the per-item tax.

- Credit/Debit Note handling so offsetting tax lines under the same account net out correctly instead of producing an inflated total.

Example

- Create two items in the Purchase Invoice
<img width="1148" height="361" alt="Screenshot 2569-07-27 at 10 11 01" src="https://github.com/user-attachments/assets/72559dff-5a96-47c0-9b75-a134285409af" />

- item: 7% VAT
<img width="1183" height="645" alt="Screenshot 2569-07-27 at 10 11 30" src="https://github.com/user-attachments/assets/303badee-9372-4c39-b207-0955ab8c71de" />

- Service fee: 0% VAT
<img width="1185" height="617" alt="Screenshot 2569-07-27 at 10 11 41" src="https://github.com/user-attachments/assets/2b80ca41-7a9d-4b9c-bea6-1d0977c8aa5d" />

- The system will calculate the combined VAT
<img width="1148" height="288" alt="Screenshot 2569-07-27 at 10 11 49" src="https://github.com/user-attachments/assets/445041e8-43d9-4544-afaf-46c134eb2817" />


- And generate a Tax Invoice
<img width="1145" height="306" alt="Screenshot 2569-07-27 at 10 11 59" src="https://github.com/user-attachments/assets/db4485aa-8f1b-485a-a98f-c48e645def77" />

